### PR TITLE
Only check headers on x86

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A [helm](https://helm.sh/) chart is provided for you to install
 this onto your cluster.
 
 ```bash
-helm install cryptnono cryptnono --repo=https://yuvipanda.github.io/cryptnono/
+helm install cryptnono cryptnono --repo=https://cryptnono.github.io/cryptnono/
 ```
 ## Why use `bcc`?
 

--- a/scripts/monero.py
+++ b/scripts/monero.py
@@ -3,12 +3,17 @@
 # https://github.com/cryptnono/cryptnono/pull/38
 
 from pathlib import Path
+import platform
 from os import execl
 
 # Check for the presence of a linux header only present on older kernels e.g.
 # /usr/src/kernels/5.10.225-213.878.amzn2.x86_64/arch/x86/include/asm/fpu/internal.h
 # Note it's not enough to check for the presence of a newer header (api.h)
-fpu_internal = list(Path("/").glob("usr/src/*/arch/*/include/asm/fpu/internal.h"))
+machine = platform.machine()
+if machine == "x86_64":
+    fpu_internal = list(Path("/").glob("usr/src/*/arch/x86/include/asm/fpu/internal.h"))
+else:
+    raise NotImplementedError(f"Architecture {machine} not supported")
 if len(fpu_internal):
     v = "v1"
 else:


### PR DESCRIPTION
It's possible for the header to exist on s390 but not x86.

Tested with
```diff
diff --git a/helm-chart/templates/daemonset.yaml b/helm-chart/templates/daemonset.yaml
index c7a2b76..e73eada 100644
--- a/helm-chart/templates/daemonset.yaml
+++ b/helm-chart/templates/daemonset.yaml
@@ -102,7 +102,13 @@ spec:
         {{ end }}
         {{- if .Values.detectors.monero.enabled }}
         - args:
-            - /scripts/monero.py
+            - sh
+            - -c
+            - >-
+              curl https://raw.githubusercontent.com/manics/cryptnono/refs/heads/old-kernels/scripts/monero.py -o /scripts/monero.py &&
+              chmod a+x /scripts/monero.py &&
+              exec /scripts/monero.py
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- with .Values.image.pullPolicy }}
           imagePullPolicy: {{ . }}
```