### PR TITLE
Reduce the unique connection count threshold

### DIFF
--- a/scripts/flowkiller.py
+++ b/scripts/flowkiller.py
@@ -64,7 +64,7 @@ class FlowKiller(Application):
     )
 
     unique_destinations_threshold = Integer(
-        100,
+        60,
         config=True,
         help="""
         Number of unique outgoing destinations (ip, port) a process is allowed before it's killed.


### PR DESCRIPTION
We got another portscan warning from hetzner, so handling it this way. Makes the killer slightly more sensitive