### PR TITLE
Reduce default threshold even further

### DIFF
--- a/scripts/flowkiller.py
+++ b/scripts/flowkiller.py
@@ -64,7 +64,7 @@ class FlowKiller(Application):
     )
 
     unique_destinations_threshold = Integer(
-        60,
+        20,
         config=True,
         help="""
         Number of unique outgoing destinations (ip, port) a process is allowed before it's killed.


### PR DESCRIPTION
Hetzner continues to have concerns about this being portscanning rather than a retry loop :( They have told me that if this triggers again, the 2i2c server will not be unlocked.