### PR TITLE
podAnnotations: fix indent

### DIFF
--- a/helm-chart/templates/daemonset.yaml
+++ b/helm-chart/templates/daemonset.yaml
@@ -20,7 +20,7 @@ spec:
         prometheus.io/path: "/metrics"
         {{- end}}
         {{- with .Values.podAnnotations }}
-        {{- . | toYaml | nindent 10 }}
+        {{- . | toYaml | nindent 8 }}
         {{- end }}
       labels:
         {{- include "cryptnono.selectorLabels" . | nindent 10 }}


### PR DESCRIPTION
The current indentation is too large resulting in invalid YAML when `podAnnotations:` are set.