### PR TITLE
tcpflowkiller: configure banned_ipv4_file_globs in Helm chart by default and provide initial docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ detectors:
     #
     #     kubectl create configmap my-configmap-name --from-file=filename-with-banned-ips.txt
     #
-    bannedIpv4ConfigMaps: []
-      # - my-configmap-name: filename-with-banned-ips.txt
+    bannedIpv4ConfigMaps: {}
+      # my-configmap-name: filename-with-banned-ips.txt
 ```
 
 ## Development

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -74,8 +74,8 @@ detectors:
     #
     #     kubectl create configmap my-configmap-name --from-file=filename-with-banned-ips.txt
     #
-    bannedIpv4ConfigMaps: []
-      # - my-configmap-name: filename-with-banned-ips.txt
+    bannedIpv4ConfigMaps: {}
+      # my-configmap-name: filename-with-banned-ips.txt
     #
     # Passthrough configuration of traitlet based Python classes
     config:


### PR DESCRIPTION
`FlowKiller.banned_ipv4_file_globs` in the flowkiller.py maybe shouldn't have a default value. The Helm chart however, that mounts chart configured `tcpflowkiller.bannedIpv4ConfigMaps` configmaps to `/ban-config/` (hardcoded), should configure `FlowKiller.banned_ipv4_file_globs` by default to recognize those files.

With these changes, it also became easier to document how to setup `tcpflowkiller` as done as part of this PR. I also included a small YAML indentation refactor.

I expect these changes to not break anything, but allow people to no longer manually configure `tcpflowkiller.config.FlowKiller.banned_ipv4_file_globs` alongside `tcpflowkiller.bannedIpv4ConfigMaps`.