### PR TITLE
helm: defaults for containerd and docker socket paths

### DIFF
--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -60,9 +60,9 @@ detectors:
       prometheusScrape: true
     threadpoolSize: 10
     # Host absolute path to containerd.sock
-    containerdHostPath:
+    containerdHostPath: /run/containerd/containerd.sock
     # Host absolute path to docker.sock
-    dockerHostPath:
+    dockerHostPath: /var/run/docker.sock
   monero:
     enabled: true
     resources: {}
@@ -93,9 +93,9 @@ detectors:
     env: {}
     resources: {}
     # Host absolute path to containerd.sock
-    containerdHostPath:
+    containerdHostPath: /run/containerd/containerd.sock
     # Host absolute path to docker.sock
-    dockerHostPath:
+    dockerHostPath: /var/run/docker.sock
     # Metrics aren't implemented
     # https://github.com/cryptnono/cryptnono/issues/50
     metrics:


### PR DESCRIPTION
I considered if we wanted to declare these defaults in the python software or the Helm chart, and concluded we want them in the Helm chart, because the Helm chart config should be prepended with `/host` to the path as we have mounted the host node's filesystem there.

I think it is better to leave the default value for non-helm situation as it is, which also seem to work fine.

Both the configured default values, `/run/containerd/containerd.sock` and `/var/run/docker.sock` were mentioned in https://kubernetes.io/docs/setup/production-environment/container-runtimes/ as default values for the respective container runtimes.

It should be fine if either `CONTAINER_RUNTIME_ENDPOINT` or `DOCKER_HOST` are declared envs on our containers even though they are not used, so this should be non-breaking.