### PR TITLE
Disable Counter metric's associated _created gauge

### DIFF
--- a/scripts/execwhacker.py
+++ b/scripts/execwhacker.py
@@ -26,7 +26,12 @@ from lookup_container import (
     lookup_container_details_crictl,
     lookup_container_details_docker,
 )
-from prometheus_client import Counter, Histogram, start_http_server
+from prometheus_client import (
+    Counter,
+    Histogram,
+    disable_created_metrics,
+    start_http_server,
+)
 from psutil import NoSuchProcess, process_iter
 
 # Lazily initialised with configuration on first use
@@ -487,6 +492,9 @@ def main():
     logging.info(f"Took {startup_duration:0.2f}s to startup")
 
     if args.serve_metrics_port:
+        # disable Counter's associated _created gauge timeseries as they aren't
+        # needed
+        disable_created_metrics()
         start_http_server(args.serve_metrics_port)
 
     if args.scan_existing:

--- a/scripts/flowkiller.py
+++ b/scripts/flowkiller.py
@@ -23,7 +23,12 @@ from lookup_container import (
     lookup_container_details_crictl,
     lookup_container_details_docker,
 )
-from prometheus_client import Counter, Histogram, start_http_server
+from prometheus_client import (
+    Counter,
+    Histogram,
+    disable_created_metrics,
+    start_http_server,
+)
 from psutil import NoSuchProcess, Process
 from traitlets import Bool, Dict, Integer, List, Unicode
 from traitlets.config import Application
@@ -318,6 +323,9 @@ class FlowKiller(Application):
         b["ipv6_events"].open_perf_buffer(partial(self.handle_event, "ipv6_events", b))
 
         if self.metrics_port:
+            # disable Counter's associated _created gauge timeseries as they
+            # aren't needed
+            disable_created_metrics()
             start_http_server(self.metrics_port)
 
         self.log.info("Watching for processes we don't like...")


### PR DESCRIPTION
The Counter type metrics will emit `_total` and `_created` time series,
where the `_created` timeseries is a contant of gague type.

With the introduction of OpenMetrics, the `_created` timeseries will be
converted to `_created_total` and it is a bit messy.

Their purpose related to detecting if the `_total` counter was reset,
but there is detection logic for that without a `_created` timestamp as
well.

So I propose we drop it to make things simpler. Having done that, an
opentelemetry-collector's served metrics will be the same as a
prometheus-client's served metrics.
