### PR TITLE
Update crictl version from 1.29.0 to 1.34.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ RUN apt-get update --yes >/dev/null && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-ARG CRICTL_VERSION=1.29.0
+# available crictl versions: https://github.com/kubernetes-sigs/cri-tools/tags
+ARG CRICTL_VERSION=1.33.0
 RUN MACHINE=`uname -m`; \
     if [ "$MACHINE" = "x86_64" ]; then \
         ARCH=amd64; \


### PR DESCRIPTION
I have verified that use of `crictl`, the old 1.29, and the new 1.34, works fine with cryptnono on a GKE v1.33 cluster with containerd. Since all we do is use `crictl inspect`, I don't expect much issues related to this bump.