### PR TITLE
Handle buildkit, show cgroup in logs, show selected env vars in logs

### DIFF
--- a/helm-chart/templates/daemonset.yaml
+++ b/helm-chart/templates/daemonset.yaml
@@ -39,6 +39,10 @@ spec:
             - --config
             - /config/execwhacker-{{ $key }}.json
             {{ end }}
+            {{- range .Values.detectors.execwhacker.lookupEnvs }}
+            - --lookup-container-env
+            - {{ . }}
+            {{ end }}
             {{- if .Values.detectors.execwhacker.debug }}
             - --debug
             {{ end}}

--- a/helm-chart/values.schema.yaml
+++ b/helm-chart/values.schema.yaml
@@ -105,6 +105,11 @@ properties:
                     type: string
           env: &detector-env-spec
             type: object
+          lookupEnvs:
+            type: array
+            description: List of container environment variables to include in logs
+            items:
+              type: string
           metrics: &detector-metrics-spec
             type: object
             additionalProperties: false

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -46,6 +46,8 @@ detectors:
         #   - "allowed\\s+cryptnono\\.banned\\.string1"
     # Optional environment variables
     env: {}
+    # Include these container environment variables in logs
+    lookupEnvs: []
     metrics:
       port: 12121
     threadpoolSize: 10

--- a/scripts/execwhacker.py
+++ b/scripts/execwhacker.py
@@ -112,7 +112,7 @@ kill_if_needed_histogram = Histogram(
 
 
 @log_and_kill_histogram.time()
-def log_and_kill(pid, cmdline, b, source, lookup_container):
+def log_and_kill(pid, cmdline, b, source, lookup_container, lookup_container_envs):
     """
     Attempt to lookup the container details for a given PID, then log and kill it
 
@@ -134,7 +134,9 @@ def log_and_kill(pid, cmdline, b, source, lookup_container):
             log.info(e, action="container-lookup-failed")
         else:
             try:
-                container_info = lookup_container_details(cid, container_type)
+                container_info = lookup_container_details(
+                    cid, container_type, lookup_container_envs
+                )
                 log = log.bind(**container_info)
             except ContainerNotFound as e:
                 log.info(e, action="container-lookup-failed")
@@ -189,6 +191,7 @@ def kill_if_needed(
     source,
     executor,
     lookup_container,
+    lookup_container_envs,
 ):
     """
     Kill given process (pid) with cmdline if appropriate, based on banned_command_strings
@@ -247,6 +250,7 @@ def kill_if_needed(
                 b,
                 source,
                 lookup_container,
+                lookup_container_envs,
             )
             return future
     processes_allowed.labels(
@@ -262,6 +266,7 @@ def process_event(
     allowed_patterns: list,
     executor: Executor,
     lookup_container: bool,
+    lookup_container_envs: list[str],
     ctx,
     data,
     size,
@@ -289,6 +294,7 @@ def process_event(
             ProcessSource.BPF,
             executor,
             lookup_container,
+            lookup_container_envs,
         )
         duration = time.perf_counter() - start_time
 
@@ -310,7 +316,12 @@ def process_event(
 
 
 def check_existing_processes(
-    banned_strings_automaton, allowed_patterns, interval, executor, lookup_container
+    banned_strings_automaton,
+    allowed_patterns,
+    interval,
+    executor,
+    lookup_container,
+    lookup_container_envs,
 ):
     """
     Scan all running processes for banned strings
@@ -331,6 +342,7 @@ def check_existing_processes(
                         source,
                         executor,
                         lookup_container,
+                        lookup_container_envs,
                     )
             except NoSuchProcess as e:
                 logging.info(
@@ -386,6 +398,13 @@ def main():
         "--lookup-container",
         action="store_true",
         help="Attempt to lookup the container details for a process before killing it",
+    )
+
+    parser.add_argument(
+        "--lookup-container-env",
+        action="append",
+        default=[],
+        help="If --lookup-container is set then include these container environment variables",
     )
 
     args = parser.parse_args()
@@ -478,6 +497,7 @@ def main():
             allowed_patterns,
             executor,
             args.lookup_container,
+            args.lookup_container_env,
         )
     )
 
@@ -501,6 +521,7 @@ def main():
                 args.scan_existing,
                 executor,
                 args.lookup_container,
+                args.lookup_container_env,
             ),
         )
         t.daemon = True

--- a/scripts/execwhacker.py
+++ b/scripts/execwhacker.py
@@ -133,6 +133,7 @@ def log_and_kill(pid, cmdline, b, source, lookup_container):
         try:
             cid, cgroupline, container_type = get_container_id(pid)
         except ContainerNotFound as e:
+            log.bind(cgroupline=e.cgroupline)
             log.info(e, action="container-lookup-failed")
             cid = None
         if cid:

--- a/scripts/execwhacker.py
+++ b/scripts/execwhacker.py
@@ -21,11 +21,8 @@ import structlog
 from bcc import BPF
 from lookup_container import (
     ContainerNotFound,
-    ContainerType,
     get_container_id,
-    lookup_container_details_buildkit,
-    lookup_container_details_crictl,
-    lookup_container_details_docker,
+    lookup_container_details,
 )
 from prometheus_client import (
     Counter,
@@ -126,29 +123,22 @@ def log_and_kill(pid, cmdline, b, source, lookup_container):
     Returns True if the process was killed, False if it was not found
     """
 
-    cid = None
     log = logging.bind(pid=pid, cmdline=cmdline, matched=b, source=source.value)
 
     if lookup_container:
         try:
             cid, cgroupline, container_type = get_container_id(pid)
         except ContainerNotFound as e:
-            log.bind(cgroupline=e.cgroupline)
+            cgroupline = e.cgroupline
+            log = log.bind(cgroupline=cgroupline)
             log.info(e, action="container-lookup-failed")
-            cid = None
-        if cid:
+        else:
             try:
-                if container_type == ContainerType.CRI:
-                    container_info = lookup_container_details_crictl(cid)
-                elif container_type == ContainerType.BUILDKIT:
-                    container_info = lookup_container_details_buildkit(cid)
-                elif container_type == ContainerType.DOCKER:
-                    container_info = lookup_container_details_docker(cid)
-                else:
-                    raise ValueError(f"Unknown container type {container_type}")
+                container_info = lookup_container_details(cid, container_type)
                 log = log.bind(**container_info)
             except ContainerNotFound as e:
-                log.info(e, action="container-lookup-failed", cgroupline=cgroupline)
+                log = log.bind(cgroupline=cgroupline)
+                log.info(e, action="container-lookup-failed")
             except Exception as e:
                 log.exception(e)
 

--- a/scripts/execwhacker.py
+++ b/scripts/execwhacker.py
@@ -128,16 +128,15 @@ def log_and_kill(pid, cmdline, b, source, lookup_container):
     if lookup_container:
         try:
             cid, cgroupline, container_type = get_container_id(pid)
+            log = log.bind(cgroup=cgroupline)
         except ContainerNotFound as e:
-            cgroupline = e.cgroupline
-            log = log.bind(cgroupline=cgroupline)
+            log = log.bind(cgroup=e.cgroupline)
             log.info(e, action="container-lookup-failed")
         else:
             try:
                 container_info = lookup_container_details(cid, container_type)
                 log = log.bind(**container_info)
             except ContainerNotFound as e:
-                log = log.bind(cgroupline=cgroupline)
                 log.info(e, action="container-lookup-failed")
             except Exception as e:
                 log.exception(e)

--- a/scripts/execwhacker.py
+++ b/scripts/execwhacker.py
@@ -23,6 +23,7 @@ from lookup_container import (
     ContainerNotFound,
     ContainerType,
     get_container_id,
+    lookup_container_details_buildkit,
     lookup_container_details_crictl,
     lookup_container_details_docker,
 )
@@ -138,6 +139,8 @@ def log_and_kill(pid, cmdline, b, source, lookup_container):
             try:
                 if container_type == ContainerType.CRI:
                     container_info = lookup_container_details_crictl(cid)
+                elif container_type == ContainerType.BUILDKIT:
+                    container_info = lookup_container_details_buildkit(cid)
                 elif container_type == ContainerType.DOCKER:
                     container_info = lookup_container_details_docker(cid)
                 else:

--- a/scripts/flowkiller.py
+++ b/scripts/flowkiller.py
@@ -102,6 +102,15 @@ class FlowKiller(Application):
         """,
     )
 
+    log_container_envs = List(
+        Unicode(),
+        [],
+        config=True,
+        help="""
+        If log_container_info is set then include these container environment variables
+        """,
+    )
+
     lookback_duration_seconds = Integer(
         30,
         config=True,
@@ -198,7 +207,9 @@ class FlowKiller(Application):
             log.info(e, action="container-lookup-failed")
         else:
             try:
-                container_info = lookup_container_details(cid, container_type)
+                container_info = lookup_container_details(
+                    cid, container_type, self.log_container_envs
+                )
                 return container_info
             except ContainerNotFound as e:
                 log.info(e, action="container-lookup-failed")

--- a/scripts/flowkiller.py
+++ b/scripts/flowkiller.py
@@ -192,17 +192,16 @@ class FlowKiller(Application):
         log = self.log.bind(pid=pid)
         try:
             cid, cgroupline, container_type = get_container_id(pid)
+            log = log.bind(cgroup=cgroupline)
         except ContainerNotFound as e:
-            cgroupline = e.cgroupline
-            log = log.bind(cgroupline=cgroupline)
+            log = log.bind(cgroup=e.cgroupline)
             log.info(e, action="container-lookup-failed")
         else:
             try:
                 container_info = lookup_container_details(cid, container_type)
                 return container_info
             except ContainerNotFound as e:
-                log = log.bind(cgroupline=cgroupline)
-                log.info(e, action="container-lookup-failed", cgroupline=cgroupline)
+                log.info(e, action="container-lookup-failed")
             except Exception as e:
                 log.exception(e)
         return None

--- a/scripts/flowkiller.py
+++ b/scripts/flowkiller.py
@@ -18,11 +18,8 @@ from bcc import BPF
 from cachetools import TTLCache, cached
 from lookup_container import (
     ContainerNotFound,
-    ContainerType,
     get_container_id,
-    lookup_container_details_buildkit,
-    lookup_container_details_crictl,
-    lookup_container_details_docker,
+    lookup_container_details,
 )
 from prometheus_client import (
     Counter,
@@ -192,29 +189,22 @@ class FlowKiller(Application):
     # Cache only for an hour, pid reuse should not be an issue here
     @cached(cache=TTLCache(1024, 60 * 60))
     def get_container_info(self, pid):
+        log = self.log.bind(pid=pid)
         try:
             cid, cgroupline, container_type = get_container_id(pid)
         except ContainerNotFound as e:
-            self.log.info(e, action="container-lookup-failed")
-            cid = None
-        if cid:
+            cgroupline = e.cgroupline
+            log = log.bind(cgroupline=cgroupline)
+            log.info(e, action="container-lookup-failed")
+        else:
             try:
-                if container_type == ContainerType.CRI:
-                    container_info = lookup_container_details_crictl(cid)
-                elif container_type == ContainerType.BUILDKIT:
-                    container_info = lookup_container_details_buildkit(cid)
-                elif container_type == ContainerType.DOCKER:
-                    container_info = lookup_container_details_docker(cid)
-                else:
-                    raise ValueError(f"Unknown container type {container_type}")
-
+                container_info = lookup_container_details(cid, container_type)
                 return container_info
             except ContainerNotFound as e:
-                self.log.info(
-                    e, action="container-lookup-failed", cgroupline=cgroupline
-                )
+                log = log.bind(cgroupline=cgroupline)
+                log.info(e, action="container-lookup-failed", cgroupline=cgroupline)
             except Exception as e:
-                self.log.exception(e)
+                log.exception(e)
         return None
 
     @log_and_kill_histogram.time()

--- a/scripts/flowkiller.py
+++ b/scripts/flowkiller.py
@@ -20,6 +20,7 @@ from lookup_container import (
     ContainerNotFound,
     ContainerType,
     get_container_id,
+    lookup_container_details_buildkit,
     lookup_container_details_crictl,
     lookup_container_details_docker,
 )
@@ -200,6 +201,8 @@ class FlowKiller(Application):
             try:
                 if container_type == ContainerType.CRI:
                     container_info = lookup_container_details_crictl(cid)
+                elif container_type == ContainerType.BUILDKIT:
+                    container_info = lookup_container_details_buildkit(cid)
                 elif container_type == ContainerType.DOCKER:
                     container_info = lookup_container_details_docker(cid)
                 else:

--- a/scripts/lookup_container.py
+++ b/scripts/lookup_container.py
@@ -5,7 +5,6 @@ import re
 import subprocess
 from enum import Enum
 from os import getenv
-from typing import Optional
 
 import docker
 
@@ -17,7 +16,9 @@ class ContainerType(Enum):
 
 
 class ContainerNotFound(Exception):
-    pass
+    def __init__(self, *args, cgroupline: str | None = None) -> None:
+        super().__init__(*args)
+        self.cgroupline = cgroupline
 
 
 def get_container_id(
@@ -73,7 +74,10 @@ def get_container_id(
 
         # TODO: We may need to parse cgroup values for other container runtimes here
 
-    raise ContainerNotFound(f"Could not find container ID for PID {pid}")
+    # Just return first cgroup line since there may be a several
+    raise ContainerNotFound(
+        f"Could not find container ID for PID {pid}", cgroupline=lines[0].strip()
+    )
 
 
 def lookup_container_details_crictl(container_id: str) -> dict[str, str]:

--- a/scripts/lookup_container.py
+++ b/scripts/lookup_container.py
@@ -13,6 +13,7 @@ import docker
 class ContainerType(Enum):
     CRI = "cri"
     DOCKER = "docker"
+    BUILDKIT = "buildkit"
 
 
 class ContainerNotFound(Exception):
@@ -54,15 +55,24 @@ def get_container_id(
         cri = re.search(r"containerd-(\w+).scope$", line)
         if cri:
             return cri.group(1), line, ContainerType.CRI
+
+        # Docker Buildkit (ID is for builder, not for container)
+        docker_buildkit = re.search(r"docker/buildkit/(\w+)$", line)
+        if docker_buildkit:
+            return docker_buildkit.group(1), line, ContainerType.BUILDKIT
+
         # Kubernetes DinD (BinderHub)
         docker_in_cri = re.search(r"docker/(\w+)$", line)
         if docker_in_cri:
             return docker_in_cri.group(1), line, ContainerType.DOCKER
+
         # Docker
         docker_host = re.search(r"docker-(\w+).scope$", line)
         if docker_host:
             return docker_host.group(1), line, ContainerType.DOCKER
+
         # TODO: We may need to parse cgroup values for other container runtimes here
+
     raise ContainerNotFound(f"Could not find container ID for PID {pid}")
 
 
@@ -112,5 +122,19 @@ def lookup_container_details_docker(container_id: str) -> dict[str, str]:
         "container_type": ContainerType.DOCKER.value,
         "image": container["Image"],
         "labels": container["Config"]["Labels"],
+    }
+    return container_info
+
+
+def lookup_container_details_buildkit(container_id: str) -> dict[str, str]:
+    """
+    Return placeholder information about a BuildKit runner
+
+    container_id: BuildKit builder ID
+    returns: dictionary with placeholder information
+    """
+    container_info = {
+        "container_type": ContainerType.BUILDKIT.value,
+        "builder_id": container_id,
     }
     return container_info

--- a/scripts/lookup_container.py
+++ b/scripts/lookup_container.py
@@ -152,3 +152,15 @@ def lookup_container_details_buildkit(container_id: str) -> dict[str, str]:
         "builder_id": container_id,
     }
     return container_info
+
+
+def lookup_container_details(
+    container_id: str, container_type: ContainerType
+) -> dict[str, str]:
+    if container_type == ContainerType.CRI:
+        return lookup_container_details_crictl(container_id)
+    if container_type == ContainerType.BUILDKIT:
+        return lookup_container_details_buildkit(container_id)
+    if container_type == ContainerType.DOCKER:
+        return lookup_container_details_docker(container_id)
+    raise ValueError(f"Unknown container type {container_type}")

--- a/scripts/lookup_container.py
+++ b/scripts/lookup_container.py
@@ -42,6 +42,16 @@ def get_container_id(
     # Docker (Repo2docker via DinD):
     #   Basically found by inspection
 
+    # /proc/pid/cgroup
+    # https://man7.org/linux/man-pages/man7/cgroups.7.html
+    # hierarchy-ID:controller-list:cgroup-path
+    #
+    # hierarchy-ID: Always 0 in cgroups v2
+    # controller-list: Always empty in cgroups v2
+    # cgroup-path: pathname of the control group
+    #
+    # i.e. for cgroups v2 this always starts with 0::/
+
     if cgroup_file is None:
         cgroup_file = f"/proc/{pid}/cgroup"
     try:

--- a/scripts/lookup_container.py
+++ b/scripts/lookup_container.py
@@ -90,27 +90,20 @@ def get_container_id(
     )
 
 
-def lookup_container_details_crictl(container_id: str) -> dict[str, str]:
+def lookup_container_details_crictl(
+    container_id: str, include_envvars: list[str]
+) -> dict[str, str]:
     """
     Find information about a K8s pod by CRI container ID using crictl.
 
     https://kubernetes.io/docs/tasks/debug/debug-cluster/crictl/
     container_id: CRI container ID
+    include_envvars: List of container environment variables to include
     returns: dictionary with information about container
     """
     cmd = ["crictl", "inspect", container_id]
     try:
         p = subprocess.run(cmd, capture_output=True, timeout=2, check=True)
-        container = json.loads(p.stdout)
-        labels = container.get("status", {}).get("labels", None)
-        image = container.get("status", {}).get("image", {}).get("image", None)
-
-        container_info = {"container_type": ContainerType.CRI.value}
-        if labels is not None:
-            container_info["labels"] = labels
-        if image is not None:
-            container_info["image"] = image
-        return container_info
     except subprocess.CalledProcessError as e:
         if e.returncode == 1:
             raise ContainerNotFound(
@@ -118,12 +111,33 @@ def lookup_container_details_crictl(container_id: str) -> dict[str, str]:
             ) from None
         raise
 
+    container = json.loads(p.stdout)
+    labels = container.get("status", {}).get("labels", None)
+    image = container.get("status", {}).get("image", {}).get("image", None)
 
-def lookup_container_details_docker(container_id: str) -> dict[str, str]:
+    container_info = {"container_type": ContainerType.CRI.value}
+    if labels is not None:
+        container_info["labels"] = labels
+    if image is not None:
+        container_info["image"] = image
+    if include_envvars:
+        container_info["env"] = {}
+        envs = container.get("info", {}).get("config", {}).get("envs", [])
+        for env in envs:
+            if env["key"] in include_envvars:
+                container_info["env"][env["key"]] = env.get("value")
+
+    return container_info
+
+
+def lookup_container_details_docker(
+    container_id: str, include_envvars: list[str]
+) -> dict[str, str]:
     """
     Find information about a Docker container.
 
     container_id: CRI container ID
+    include_envvars: List of container environment variables to include
     returns: dictionary with information about container
     """
     client = docker.APIClient(getenv("DOCKER_HOST"))
@@ -137,6 +151,12 @@ def lookup_container_details_docker(container_id: str) -> dict[str, str]:
         "image": container["Image"],
         "labels": container["Config"]["Labels"],
     }
+    if include_envvars:
+        container_info["env"] = {}
+        for kv in container["Config"]["Env"]:
+            k, v = kv.split("=", 1)
+            if k in include_envvars:
+                container_info["env"][k] = v
     return container_info
 
 
@@ -155,12 +175,12 @@ def lookup_container_details_buildkit(container_id: str) -> dict[str, str]:
 
 
 def lookup_container_details(
-    container_id: str, container_type: ContainerType
+    container_id: str, container_type: ContainerType, include_envvars: list[str]
 ) -> dict[str, str]:
     if container_type == ContainerType.CRI:
-        return lookup_container_details_crictl(container_id)
+        return lookup_container_details_crictl(container_id, include_envvars)
     if container_type == ContainerType.BUILDKIT:
         return lookup_container_details_buildkit(container_id)
     if container_type == ContainerType.DOCKER:
-        return lookup_container_details_docker(container_id)
+        return lookup_container_details_docker(container_id, include_envvars)
     raise ValueError(f"Unknown container type {container_type}")

--- a/tests/resources/proc-pid-cgroup-docker-buildx.txt
+++ b/tests/resources/proc-pid-cgroup-docker-buildx.txt
@@ -1,0 +1,1 @@
+0::/docker/buildkit/4jl3bwj1k8b1s2w8n2ggm9424

--- a/tests/resources/proc-pid-cgroup-system-service.txt
+++ b/tests/resources/proc-pid-cgroup-system-service.txt
@@ -1,0 +1,1 @@
+0::/system.slice/unattended-upgrades.service

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -57,6 +57,13 @@ def test_get_container_id():
         ContainerType.BUILDKIT,
     )
 
+    # Mock data (PID ignored) for system service, not a container
+    with pytest.raises(ContainerNotFound) as exc:
+        get_container_id(
+            12345, str(RESOURCES_DIR / "proc-pid-cgroup-system-service.txt")
+        )
+    assert exc.value.cgroupline == "0::/system.slice/unattended-upgrades.service"
+
     # This should be a real PID, of the root init process, so this should fail
     with pytest.raises(ContainerNotFound):
         get_container_id(1)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -69,7 +69,10 @@ def test_get_container_id():
         get_container_id(1)
 
 
-def test_lookup_container_details_crictl():
+@pytest.mark.parametrize(
+    "include_envvars", [[], ["BINDER_REPO_URL", "NON_EXISTENT_VAR"]]
+)
+def test_lookup_container_details_crictl(include_envvars):
     mock_data = (RESOURCES_DIR / "crictl-inspect.json").read_bytes()
     mock_return = subprocess.CompletedProcess(
         args=["crictl", "inspect", MOCK_CRI_CID],
@@ -79,7 +82,7 @@ def test_lookup_container_details_crictl():
     )
 
     with patch("subprocess.run", return_value=mock_return) as mock_run:
-        container_info = lookup_container_details_crictl(MOCK_CRI_CID)
+        container_info = lookup_container_details_crictl(MOCK_CRI_CID, include_envvars)
 
         mock_run.assert_called_once_with(
             ["crictl", "inspect", MOCK_CRI_CID],
@@ -88,7 +91,7 @@ def test_lookup_container_details_crictl():
             check=True,
         )
 
-    assert container_info == {
+    expected_container_info = {
         "container_type": "cri",
         "image": "container.example.org/binderhub/binder-2dexamples-2dconda-8677da:f00a783146e9c6a2ed9726f01fc09fbfbad2f89e",
         "labels": {
@@ -98,6 +101,12 @@ def test_lookup_container_details_crictl():
             "io.kubernetes.pod.uid": "7eed019f-1bfb-404f-8e0a-5687726fade6",
         },
     }
+    if include_envvars:
+        expected_container_info["env"] = {
+            "BINDER_REPO_URL": "https://github.com/binder-examples/conda"
+        }
+
+    assert container_info == expected_container_info
 
 
 def test_lookup_missing_container_details_crictl():
@@ -105,7 +114,7 @@ def test_lookup_missing_container_details_crictl():
         "subprocess.run", side_effect=ContainerNotFound("Mock exception")
     ) as mock_run:
         with pytest.raises(ContainerNotFound):
-            lookup_container_details_crictl("nonexistent")
+            lookup_container_details_crictl("nonexistent", [])
         mock_run.assert_called_once_with(
             ["crictl", "inspect", "nonexistent"],
             capture_output=True,
@@ -123,18 +132,21 @@ def test_lookup_container_details_buildkit():
     }
 
 
-def test_lookup_container_details_docker():
+@pytest.mark.parametrize("include_envvars", [[], ["NB_USER", "NON_EXISTENT_VAR"]])
+def test_lookup_container_details_docker(include_envvars):
     mock_data = json.loads((RESOURCES_DIR / "docker-inspect.json").read_bytes())
 
     with patch(
         "docker.APIClient",
         return_value=MagicMock(inspect_container=MagicMock(return_value=mock_data)),
     ) as mock_client:
-        container_info = lookup_container_details_docker(MOCK_CRI_DIND_CID)
+        container_info = lookup_container_details_docker(
+            MOCK_CRI_DIND_CID, include_envvars
+        )
 
         mock_client().inspect_container.assert_called_once_with(MOCK_CRI_DIND_CID)
 
-    assert container_info == {
+    expected_container_info = {
         "container_type": "docker",
         "image": "sha256:040235dc5a23a454ee42151986c7c9b11c7a8f5f88c5f30af75733e205088ab4",
         "labels": {
@@ -145,6 +157,10 @@ def test_lookup_container_details_docker():
             "repo2docker.version": "2023.06.0+41.g57d229e",
         },
     }
+    if include_envvars:
+        expected_container_info["env"] = {"NB_USER": "jovyan"}
+
+    assert container_info == expected_container_info
 
 
 def test_lookup_missing_container_details_docker():
@@ -155,5 +171,5 @@ def test_lookup_missing_container_details_docker():
         ),
     ) as mock_client:
         with pytest.raises(ContainerNotFound):
-            lookup_container_details_docker("nonexistent")
+            lookup_container_details_docker("nonexistent", [])
         mock_client().inspect_container.assert_called_once_with("nonexistent")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -9,6 +9,7 @@ from scripts.lookup_container import (
     ContainerNotFound,
     ContainerType,
     get_container_id,
+    lookup_container_details_buildkit,
     lookup_container_details_crictl,
     lookup_container_details_docker,
 )
@@ -17,6 +18,7 @@ RESOURCES_DIR = Path(__file__).parent / "resources"
 MOCK_CRI_CID = "4afca7c3013258aa1b81ac99fea8b68d9262f253ccb5f4ba2dd549d092afa6c3"
 MOCK_CRI_DIND_CID = "9e9192d35808d67079f075531628e7c903f4eafc7b1e495592c80951fe9e037d"
 "669735f6cb499a55be7cf29f06e82d706d2322a28e6259d2345a3ed85542a83d"
+MOCK_DOCKER_BUILDKIT_ID = "4jl3bwj1k8b1s2w8n2ggm9424"
 MOCK_DOCKER_CID = "669735f6cb499a55be7cf29f06e82d706d2322a28e6259d2345a3ed85542a83d"
 
 
@@ -43,6 +45,16 @@ def test_get_container_id():
         MOCK_DOCKER_CID,
         f"0::/system.slice/docker-{MOCK_DOCKER_CID}.scope",
         ContainerType.DOCKER,
+    )
+
+    # Use mock data (PID ignored), Docker BuildKit
+    cid = get_container_id(
+        12345, str(RESOURCES_DIR / "proc-pid-cgroup-docker-buildx.txt")
+    )
+    assert cid == (
+        MOCK_DOCKER_BUILDKIT_ID,
+        f"0::/docker/buildkit/{MOCK_DOCKER_BUILDKIT_ID}",
+        ContainerType.BUILDKIT,
     )
 
     # This should be a real PID, of the root init process, so this should fail
@@ -93,6 +105,15 @@ def test_lookup_missing_container_details_crictl():
             timeout=2,
             check=True,
         )
+
+
+def test_lookup_container_details_buildkit():
+    container_info = lookup_container_details_buildkit(MOCK_DOCKER_BUILDKIT_ID)
+
+    assert container_info == {
+        "container_type": "buildkit",
+        "builder_id": MOCK_DOCKER_BUILDKIT_ID,
+    }
 
 
 def test_lookup_container_details_docker():


### PR DESCRIPTION
cgroup: This should help us build an allowlist for processes/cgroups that shouldn't be killed
env-vars: This lets us set custom information on a container at runtime (e.g. `BINDER_REPO_URL`, or in future the client ip), and display this in the logs.