### PR TITLE
Update BPF dependencies

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,8 @@ jobs:
       matrix:
         include:
           - runs-on: ubuntu-22.04
-          - runs-on: ubuntu-26.04
+          # BPF programms fail to compile with ubuntu-26.04 kernels (too new?)
+          - runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         include:
           - runs-on: ubuntu-22.04
-          - runs-on: ubuntu-24.04
+          - runs-on: ubuntu-26.04
 
     steps:
       - uses: actions/checkout@v6
@@ -109,7 +109,7 @@ jobs:
       matrix:
         include:
           - k3s-channel: latest
-          - k3s-channel: v1.31
+          - k3s-channel: v1.34
 
     steps:
       - uses: actions/checkout@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/ubuntu:25.10
+FROM docker.io/library/ubuntu:26.04
 
 RUN apt-get update --yes >/dev/null && \
     apt-get install --yes -qq \
@@ -9,8 +9,6 @@ RUN apt-get update --yes >/dev/null && \
         python3-docker \
         python3-traitlets \
         python3-cachetools \
-        # python3-docker package is missing the distutils dependency
-        python3-distutils-extra \
         python3-prometheus-client \
         python3-structlog \
         python3-psutil \
@@ -21,7 +19,7 @@ RUN apt-get update --yes >/dev/null && \
     rm -rf /var/lib/apt/lists/*
 
 # available crictl versions: https://github.com/kubernetes-sigs/cri-tools/tags
-ARG CRICTL_VERSION=1.33.0
+ARG CRICTL_VERSION=1.36.0
 RUN MACHINE=`uname -m`; \
     if [ "$MACHINE" = "x86_64" ]; then \
         ARCH=amd64; \


### PR DESCRIPTION
CI tests no longer pass on `main`. This updates the vendored kubectl-trace, and updates the base image to ubuntu:26.04 which presumably brings in an updated BPF packages.

K8S 1.31 was failing, since it's so old I've bumped the minimum to 1.34.

Worth nothing that running on a ubuntu 26.04 CI host fails, most likely due to even more updates to the kernel